### PR TITLE
Adds printer properties dialog vertical expansion

### DIFF
--- a/ui/PrinterPropertiesDialog.ui
+++ b/ui/PrinterPropertiesDialog.ui
@@ -3596,7 +3596,7 @@ See server settings&lt;/i&gt;</property>
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
+            <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">1</property>
           </packing>


### PR DESCRIPTION
The action area of the printer properties dialog is expanded vertically when the dialog is resized.

Tested under Debian Stretch and covered in minor bug:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=858575
